### PR TITLE
Replace deprecated each function calls

### DIFF
--- a/better_exposed_filters.theme.inc
+++ b/better_exposed_filters.theme.inc
@@ -105,7 +105,8 @@ function theme_select_as_checkboxes($vars) {
     // Check for Taxonomy-based filters.
     if (is_object($elem)) {
       $slice = array_slice($elem->option, 0, 1, TRUE);
-      list($option, $elem) = each($slice);
+      $option = key($slice);
+      $elem = current($slice);
     }
 
     // Check for optgroups.  Put subelements in the $element_set array and add
@@ -176,7 +177,8 @@ function theme_select_as_hidden($vars) {
     // Check for Taxonomy-based filters.
     if (is_object($elem)) {
       $slice = array_slice($elem->option, 0, 1, TRUE);
-      list($option, $elem) = each($slice);
+      $option = key($slice);
+      $elem = current($slice);
     }
 
     // Check for optgroups.  Put subelements in the $element_set array and add a
@@ -331,7 +333,8 @@ function theme_select_as_tree($vars) {
     // Check for Taxonomy-based filters.
     if (is_object($option_label)) {
       $slice = array_slice($option_label->option, 0, 1, TRUE);
-      list($option_value, $option_label) = each($slice);
+      $option_value = key($slice);
+      $option_label = current($slice);
     }
 
     // Check for optgroups -- which is basically a two-level deep tree.
@@ -518,7 +521,8 @@ function theme_select_as_links($vars) {
     // Check for Taxonomy-based filters.
     if (is_object($elem)) {
       $slice = array_slice($elem->option, 0, 1, TRUE);
-      list($option, $elem) = each($slice);
+      $option = key($slice);
+      $elem = current($slice);
     }
 
     // Check for optgroups.  Put subelements in the $element_set array and add

--- a/views/better_exposed_filters_exposed_form_plugin.inc
+++ b/views/better_exposed_filters_exposed_form_plugin.inc
@@ -1134,7 +1134,8 @@ dateFormat: "dd-mm-yy"
                 // dsm($form[$filter_id]['#options'][$index]->option, "$filter_id at $index");
                 // Taxonomy term filters are stored as objects. Use str_replace
                 // to ensure that keep hyphens for hierarchical filters.
-                list($tid, $original) = each($form[$filter_id]['#options'][$index]->option);
+                $tid = key($form[$filter_id]['#options'][$index]->option);
+                $original = current($form[$filter_id]['#options'][$index]->option);
                 $form[$filter_id]['#options'][$index]->option[$tid] = str_replace($option, $rewrite[$option], $original);
               }
               else {
@@ -1465,7 +1466,8 @@ dateFormat: "dd-mm-yy"
             foreach ($opts as $index => $opt) {
               if (is_object($opt)) {
                 reset($opt->option);
-                list($key, $val) = each($opt->option);
+                $key = key($opt->option);
+                $val = current($opt->option);
                 $form[$filter_id]['#options'][$key] = $val;
               }
               else {
@@ -1600,7 +1602,7 @@ dateFormat: "dd-mm-yy"
             foreach ($form[$filter_id]['#options'] as $tid => $option) {
               if (is_object($option)) {
                 reset($option->option);
-                list ($tid, ) = each($option->option);
+                $tid = key($option->option);
               }
               $tids[] = $tid;
             }


### PR DESCRIPTION
Ref backdrop-contrib/better_exposed_filters#2
Applies the patch from
https://www.drupal.org/project/better_exposed_filters/issues/2946585
Replaces calls to PHP function each() which is deprecated in PHP 7.2.

Original Patch author: Jason Flatt https://www.drupal.org/u/oadaeh